### PR TITLE
FBO-AUDIT-2 - Wrong command action

### DIFF
--- a/modules/recruiting/form-portlet/src/main/java/mvc/portlet/portlet/FormPortlet.java
+++ b/modules/recruiting/form-portlet/src/main/java/mvc/portlet/portlet/FormPortlet.java
@@ -400,9 +400,18 @@ public class FormPortlet extends MVCPortlet {
 
 					
 				} else if (p == "delete") {
+					/*
+					 *  AUDIT-FBO-COMMENT: Consider removing this code if you do not use the "delete" command
+					 *  I've found no usage of this command inside of the jsps
+					 */
 					if (defaultUserId != 0) {
 						try {
-							saveData(actionRequest, actionResponse);	
+							// AUDIT-FBO-COMMENT: It should be deleteData
+							// AUDIT-FBO-REMOVE: saveData(actionRequest, actionResponse);	
+							
+							// AUDIT-FBO-ADD:
+							deleteData(actionRequest, actionResponse);
+							// end AUDIT-FBO-ADD
 						} catch (Exception e) {
 							System.out.println("error");
 						}


### PR DESCRIPTION
When I send the command "delete" to the actionRequest, I suppose you'd prefer to hit the deleteData instead of the saveData method